### PR TITLE
Add PodGroupSchGated State

### DIFF
--- a/pkg/apis/scheduling/types.go
+++ b/pkg/apis/scheduling/types.go
@@ -52,6 +52,10 @@ const (
 	// is a new state between PodGroupPending and PodGroupRunning
 	PodGroupInqueue PodGroupPhase = "Inqueue"
 
+	// PodGroupSchGated means the spec.SchedulingGates of at least one of the Pods of the job is not empty.
+	// PodGroupSchGated is transitioned from Inqueue. When spec.SchedulingGates is empty, the state goes back to Inqueue.
+	PodGroupSchGated PodGroupPhase = "SchGated"
+
 	// PodGroupCompleted means all the pods of PodGroup are completed
 	PodGroupCompleted PodGroupPhase = "Completed"
 )


### PR DESCRIPTION
We hope to add Pod Scheduling Readiness in Volcano. As mentioned in https://github.com/volcano-sh/volcano/pull/3581, we will add a new scheduling state.